### PR TITLE
Lint: Disable MissingTranslation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        disable 'MissingTranslation'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- To avoid build failure due to MissingTranslation error of Lint
  with GoogleAnalytics's generated resource.
